### PR TITLE
External gtest && gmock independent of the environment

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -2,14 +2,13 @@ cmake_minimum_required(VERSION 3.9)
 project(cpp)
 
 set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS ON)
 
-set(GTEST gtest)
-set(GTEST_BOTH_LIBRARIES
-    gtest
-    gtest_main)
+set(LIBRARY_OUTPUT_PATH build/)
+set(BINARY_OUTPUT_PATH build/)
 
-add_subdirectory(${GTEST})
-include_directories(${GTEST}/include)
+include(External_GTest.cmake)
 
 set(GILDED_ROSE_SOURCE_FILES
     GildedRose.cc
@@ -25,8 +24,18 @@ set(SOURCE_FILES
     ${GILDED_ROSE_SOURCE_FILES}
     ${GILDED_ROSE_TEXT_TESTS_SOURCE_FILES})
 
+
+
 add_executable(GildedRose ${GILDED_ROSE_SOURCE_FILES})
-target_link_libraries(GildedRose ${GTEST_BOTH_LIBRARIES})
+target_link_libraries(GildedRose ${GTEST_MAIN_LIBRARY}
+                              ${GTEST_LIBRARY}
+                              ${GMOCK_MAIN_LIBRARY}
+                              ${GMOCK_LIBRARY}
+                              ${GTEST_BOTH_LIBRARIES})
 
 add_executable(GildedRoseTextTests ${GILDED_ROSE_TEXT_TESTS_SOURCE_FILES})
-target_link_libraries(GildedRoseTextTests ${GTEST_BOTH_LIBRARIES})
+target_link_libraries(GildedRoseTextTests ${GTEST_BOTH_LIBRARIES}
+                                          ${GTEST_MAIN_LIBRARY}
+                                          ${GTEST_LIBRARY}
+                                          ${GMOCK_MAIN_LIBRARY}
+                                          ${GMOCK_LIBRARY})

--- a/cpp/External_GTest.cmake
+++ b/cpp/External_GTest.cmake
@@ -1,0 +1,58 @@
+find_package(Threads REQUIRED)
+
+include(ExternalProject)
+ExternalProject_Add(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  UPDATE_COMMAND ""
+  INSTALL_COMMAND ""
+  LOG_DOWNLOAD ON
+  LOG_CONFIGURE ON
+  LOG_BUILD ON)
+
+ExternalProject_Get_Property(googletest source_dir)
+set(GTEST_INCLUDE_DIRS ${source_dir}/googletest/include)
+set(GMOCK_INCLUDE_DIRS ${source_dir}/googlemock/include)
+
+# The cloning of the above repo doesn't happen until make, however if the dir doesn't
+# exist, INTERFACE_INCLUDE_DIRECTORIES will throw an error.
+# To make it work, we just create the directory now during config.
+file(MAKE_DIRECTORY ${GTEST_INCLUDE_DIRS})
+file(MAKE_DIRECTORY ${GMOCK_INCLUDE_DIRS})
+
+ExternalProject_Get_Property(googletest binary_dir)
+set(GTEST_LIBRARY_PATH ${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gtest.a)
+set(GTEST_LIBRARY gtest)
+add_library(${GTEST_LIBRARY} UNKNOWN IMPORTED)
+set_target_properties(${GTEST_LIBRARY} PROPERTIES
+    "IMPORTED_LOCATION" "${GTEST_LIBRARY_PATH}"
+    "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+    "INTERFACE_INCLUDE_DIRECTORIES" "${GTEST_INCLUDE_DIRS}")
+add_dependencies(${GTEST_LIBRARY} googletest)
+
+set(GTEST_MAIN_LIBRARY_PATH ${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gtest_main.a)
+set(GTEST_MAIN_LIBRARY gtest_main)
+add_library(${GTEST_MAIN_LIBRARY} UNKNOWN IMPORTED)
+set_target_properties(${GTEST_MAIN_LIBRARY} PROPERTIES
+    "IMPORTED_LOCATION" "${GTEST_MAIN_LIBRARY_PATH}"
+    "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+    "INTERFACE_INCLUDE_DIRECTORIES" "${GTEST_INCLUDE_DIRS}")
+add_dependencies(${GTEST_MAIN_LIBRARY} googletest)
+
+set(GMOCK_LIBRARY_PATH ${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gmock.a)
+set(GMOCK_LIBRARY gmock)
+add_library(${GMOCK_LIBRARY} UNKNOWN IMPORTED)
+set_target_properties(${GMOCK_LIBRARY} PROPERTIES
+    "IMPORTED_LOCATION" "${GMOCK_LIBRARY_PATH}"
+    "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+    "INTERFACE_INCLUDE_DIRECTORIES" "${GMOCK_INCLUDE_DIRS}")
+add_dependencies(${GMOCK_LIBRARY} googletest)
+
+set(GMOCK_MAIN_LIBRARY_PATH ${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gmock_main.a)
+set(GMOCK_MAIN_LIBRARY gmock_main)
+add_library(${GMOCK_MAIN_LIBRARY} UNKNOWN IMPORTED)
+set_target_properties(${GMOCK_MAIN_LIBRARY} PROPERTIES
+    "IMPORTED_LOCATION" "${GMOCK_MAIN_LIBRARY_PATH}"
+    "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+    "INTERFACE_INCLUDE_DIRECTORIES" "${GMOCK_INCLUDE_DIRS}")
+add_dependencies(${GMOCK_MAIN_LIBRARY} ${GTEST_LIBRARY})


### PR DESCRIPTION
Due to this change you will not need copy-pasting gtest library manually. It is enought to perform only below commands:
```
mkdir build
cd build/
cmake ..
make
./GildenRose
```